### PR TITLE
docs(license) : Corrected link to license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hall-Of-Fame [![](https://img.shields.io/github/release/sourcerer-io/hall-of-fame.svg?colorB=58839b)](https://github.com/sourcerer-io/hall-of-fame/releases) [![](https://img.shields.io/github/license/sourcerer-io/hall-of-fame.svg?colorB=ff0000)](https://github.com/sourcerer-io/hall-of-fame/blob/master/LICENSE.md)
+# Hall-Of-Fame [![](https://img.shields.io/github/release/sourcerer-io/hall-of-fame.svg?colorB=58839b)](https://github.com/sourcerer-io/hall-of-fame/releases) [![](https://img.shields.io/github/license/sourcerer-io/hall-of-fame.svg?colorB=ff0000)](https://github.com/sourcerer-io/hall-of-fame/blob/master/LICENSE)
 
 <img src="https://user-images.githubusercontent.com/20287615/43668986-d98186cc-9734-11e8-9c3e-3956a512be04.png" width="680px">
 


### PR DESCRIPTION
### Summary

Changed the Link within README.md file so that License badge directs to License. 

Previously License badge link gave 404 Not Found Error, when clicked. 

## Fixes #51 
### Before :

![Screenshot from 2020-10-05 16-06-34](https://user-images.githubusercontent.com/40469121/95071382-2e7d1380-0727-11eb-8a0c-14bae345d374.png)


### After : 

![Screenshot from 2020-10-05 16-24-36](https://user-images.githubusercontent.com/40469121/95071449-46ed2e00-0727-11eb-9ab7-6084eba6c107.png)

@sergey48k 